### PR TITLE
宏定义错误

### DIFF
--- a/docs/library/adc.md
+++ b/docs/library/adc.md
@@ -22,7 +22,7 @@ uint32_t analogRead(uint32_t pin);
 ```
 
 - `pin` GPIO 引脚或 ADC 通道。
-- - ADC的内部通道可以为`ATEMP` (内部温度传感器)、`AVBAT` (VBAT电压)、`AREF` (内部参考电压)。
+- - ADC的内部通道可以为`ATEMP` (内部温度传感器)、`AVBAT` (VBAT电压)、`AVREF` (内部参考电压)。
 
 该函数将返回模拟原始值。
 


### PR DESCRIPTION
在文件cores/AirMCU/pins_arduino_analog.h的48行可以查到， 校准电压的原始值的宏定义是AVREF